### PR TITLE
Update to Rust 2018: take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.15.0
+  - 1.31.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gettext"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Justinas Stankevicius <justinas@justinas.org>"]
 description = "An implementation of Gettext translation framework for Rust"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "An implementation of Gettext translation framework for Rust"
 license = "MIT"
 repository = "https://github.com/justinas/gettext"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 byteorder = "1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 //! # Example
 //!
 //! ```ignore
-//! extern crate gettext;
 //!
 //! use std::fs::File;
 //! use gettext::Catalog;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,9 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::ops::Deref;
 
-use parser::default_resolver;
-pub use parser::{Error, ParseOptions};
-use plurals::*;
+use crate::parser::default_resolver;
+pub use crate::parser::{Error, ParseOptions};
+use crate::plurals::*;
 
 fn key_with_context(context: &str, key: &str) -> String {
     let mut result = context.to_owned();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use super::Error;
-use Error::MalformedMetadata;
+use crate::Error::MalformedMetadata;
 
 #[derive(Debug)]
 pub struct MetadataMap<'a>(HashMap<&'a str, &'a str>);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ use self::encoding::types::EncodingRef;
 
 use super::plurals::{Ast, Resolver};
 use super::{Catalog, Message};
-use metadata::parse_metadata;
+use crate::metadata::parse_metadata;
 
 #[allow(non_upper_case_globals)]
 static utf8_encoding: EncodingRef = &encoding::codec::utf_8::UTF8Encoding;
@@ -39,7 +39,7 @@ pub enum Error {
     /// An unknown encoding was specified in the metadata
     UnknownEncoding,
 }
-use Error::*;
+use crate::Error::*;
 
 impl error::Error for Error {
     fn description(&self) -> &str {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,19 +1,16 @@
-use byteorder;
-use encoding;
-
 use std::borrow::Cow;
 use std::default::Default;
 use std::error;
 use std::fmt;
 use std::io;
 
-use self::byteorder::{BigEndian, ByteOrder, LittleEndian};
-use self::encoding::label::encoding_from_whatwg_label;
-use self::encoding::types::DecoderTrap::Strict;
-use self::encoding::types::EncodingRef;
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use encoding::label::encoding_from_whatwg_label;
+use encoding::types::DecoderTrap::Strict;
+use encoding::types::EncodingRef;
 
-use super::plurals::{Ast, Resolver};
-use super::{Catalog, Message};
+use crate::plurals::{Ast, Resolver};
+use crate::{Catalog, Message};
 use crate::metadata::parse_metadata;
 
 #[allow(non_upper_case_globals)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
-extern crate byteorder;
-extern crate encoding;
+use byteorder;
+use encoding;
 
 use std::borrow::Cow;
 use std::default::Default;
@@ -80,8 +80,6 @@ impl From<Cow<'static, str>> for Error {
 /// # Examples
 /// ```ignore
 /// use std::fs::File;
-///
-/// extern crate encoding;
 /// use encoding::all::ISO_8859_1;
 ///
 /// let file = File::open("french.mo").unwrap();

--- a/src/plurals.rs
+++ b/src/plurals.rs
@@ -1,4 +1,4 @@
-use parser::Error;
+use crate::parser::Error;
 
 use self::Resolver::*;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,3 @@
-extern crate encoding;
-extern crate gettext;
-
 use encoding::label::encoding_from_whatwg_label;
 use gettext::{Catalog, ParseOptions};
 


### PR DESCRIPTION
@BaptisteGelez I tried this workflow:
1. Install Rust 1.31.0
2. Run `cargo fix --edition`
3. Make additional changes according to your PR

Travis seems to pass now, even with 1.31. Not sure how to add a third-party reviewer to the PR, but maybe you could take a look.