### PR TITLE
Remove Error::description(), implement Error::source() (fix #9)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     /// An unknown encoding was specified in the metadata
     UnknownEncoding,
 }
-use Error::*;
+use self::Error::*;
 
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,24 +26,26 @@ pub enum Error {
 use Error::*;
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            BadMagic => "bad magic number",
-            DecodingError => "invalid byte sequence in a string",
-            Eof => "unxpected end of file",
-            Io(ref err) => err.description(),
-            MalformedMetadata => "metadata syntax error",
-            MisplacedMetadata => "misplaced metadata",
-            UnknownEncoding => "unknown encoding specified",
-            PluralParsing => "invalid plural expression",
+            Io(ref err) => Some(err),
+            _ => None,
         }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let self_err: &dyn error::Error = self;
-        write!(fmt, "{}", self_err.description())
+        match *self {
+            BadMagic => write!(fmt, "bad magic number"),
+            DecodingError => write!(fmt, "invalid byte sequence in a string"),
+            Eof => write!(fmt, "unxpected end of file"),
+            Io(ref err) => err.fmt(fmt),
+            MalformedMetadata => write!(fmt, "metadata syntax error"),
+            MisplacedMetadata => write!(fmt, "misplaced metadata"),
+            UnknownEncoding => write!(fmt, "unknown encoding specified"),
+            PluralParsing => write!(fmt, "invalid plural expression"),
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,60 @@
+use std::borrow::Cow;
+use std::error;
+use std::fmt;
+use std::io;
+
+/// Represents an error encountered while parsing an MO file.
+#[derive(Debug)]
+pub enum Error {
+    /// An incorrect magic number has been encountered
+    BadMagic,
+    /// An invalid byte sequence for the given encoding has been encountered
+    DecodingError,
+    /// An unexpected EOF occured
+    Eof,
+    /// An I/O error occured
+    Io(io::Error),
+    /// Incorrect syntax encountered while parsing the meta information
+    MalformedMetadata,
+    /// Meta information string was not the first string in the catalog
+    MisplacedMetadata,
+    /// Invalid Plural-Forms metadata
+    PluralParsing,
+    /// An unknown encoding was specified in the metadata
+    UnknownEncoding,
+}
+use Error::*;
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            BadMagic => "bad magic number",
+            DecodingError => "invalid byte sequence in a string",
+            Eof => "unxpected end of file",
+            Io(ref err) => err.description(),
+            MalformedMetadata => "metadata syntax error",
+            MisplacedMetadata => "misplaced metadata",
+            UnknownEncoding => "unknown encoding specified",
+            PluralParsing => "invalid plural expression",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let self_err: &dyn error::Error = self;
+        write!(fmt, "{}", self_err.description())
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(inner: io::Error) -> Error {
+        Io(inner)
+    }
+}
+
+impl From<Cow<'static, str>> for Error {
+    fn from(_: Cow<'static, str>) -> Error {
+        DecodingError
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
     unused_import_braces
 )]
 
+mod error;
 mod metadata;
 mod parser;
 mod plurals;
@@ -54,8 +55,8 @@ use std::io::Read;
 use std::ops::Deref;
 
 use crate::parser::default_resolver;
-pub use crate::parser::{Error, ParseOptions};
 use crate::plurals::*;
+pub use crate::{error::Error, parser::ParseOptions};
 
 fn key_with_context(context: &str, key: &str) -> String {
     let mut result = context.to_owned();
@@ -104,7 +105,7 @@ impl Catalog {
     /// let file = File::open("french.mo").unwrap();
     /// let catalog = Catalog::parse(file).unwrap();
     /// ```
-    pub fn parse<R: Read>(reader: R) -> Result<Self, parser::Error> {
+    pub fn parse<R: Read>(reader: R) -> Result<Self, Error> {
         ParseOptions::new().parse(reader)
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,4 @@
-use std::borrow::Cow;
 use std::default::Default;
-use std::error;
-use std::fmt;
 use std::io;
 
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
@@ -11,66 +8,11 @@ use encoding::types::EncodingRef;
 
 use crate::metadata::parse_metadata;
 use crate::plurals::{Ast, Resolver};
+use crate::Error::{self, *};
 use crate::{Catalog, Message};
 
 #[allow(non_upper_case_globals)]
 static utf8_encoding: EncodingRef = &encoding::codec::utf_8::UTF8Encoding;
-
-/// Represents an error encountered while parsing an MO file.
-#[derive(Debug)]
-pub enum Error {
-    /// An incorrect magic number has been encountered
-    BadMagic,
-    /// An invalid byte sequence for the given encoding has been encountered
-    DecodingError,
-    /// An unexpected EOF occured
-    Eof,
-    /// An I/O error occured
-    Io(io::Error),
-    /// Incorrect syntax encountered while parsing the meta information
-    MalformedMetadata,
-    /// Meta information string was not the first string in the catalog
-    MisplacedMetadata,
-    /// Invalid Plural-Forms metadata
-    PluralParsing,
-    /// An unknown encoding was specified in the metadata
-    UnknownEncoding,
-}
-use crate::Error::*;
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            BadMagic => "bad magic number",
-            DecodingError => "invalid byte sequence in a string",
-            Eof => "unxpected end of file",
-            Io(ref err) => err.description(),
-            MalformedMetadata => "metadata syntax error",
-            MisplacedMetadata => "misplaced metadata",
-            UnknownEncoding => "unknown encoding specified",
-            PluralParsing => "invalid plural expression",
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let self_err: &dyn error::Error = self;
-        write!(fmt, "{}", self_err.description())
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(inner: io::Error) -> Error {
-        Io(inner)
-    }
-}
-
-impl From<Cow<'static, str>> for Error {
-    fn from(_: Cow<'static, str>) -> Error {
-        DecodingError
-    }
-}
 
 /// ParseOptions allows setting options for parsing MO catalogs.
 ///

--- a/src/plurals.rs
+++ b/src/plurals.rs
@@ -1,4 +1,4 @@
-use crate::parser::Error;
+use crate::Error;
 
 use self::Resolver::*;
 


### PR DESCRIPTION
Moved Error into src/error.rs, implemented error::Error with source and
adapted fmt::Display

Also simplified tests macros