### PR TITLE
Allow signed int for plurals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl Catalog {
     /// with the correct plural form for the number `n` of objects.
     /// Returns msg_id if a translation does not exist and `n == 1`,
     /// msg_id_plural otherwise.
-    pub fn ngettext<'a>(&'a self, msg_id: &'a str, msg_id_plural: &'a str, n: u64) -> &'a str {
+    pub fn ngettext<'a>(&'a self, msg_id: &'a str, msg_id_plural: &'a str, n: i64) -> &'a str {
         let form_no = self.resolver.resolve(n);
         let message = self.strings.get(msg_id);
         match message.and_then(|m| m.get_translated(form_no)) {
@@ -164,7 +164,7 @@ impl Catalog {
         msg_context: &str,
         msg_id: &'a str,
         msg_id_plural: &'a str,
-        n: u64,
+        n: i64,
     ) -> &'a str {
         let key = key_with_context(msg_context, &msg_id);
         let form_no = self.resolver.resolve(n);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,7 +28,7 @@ static utf8_encoding: EncodingRef = &encoding::codec::utf_8::UTF8Encoding;
 #[derive(Default)]
 pub struct ParseOptions {
     force_encoding: Option<EncodingRef>,
-    force_plural: Option<fn(u64) -> usize>,
+    force_plural: Option<fn(i64) -> usize>,
 }
 
 impl ParseOptions {
@@ -57,7 +57,7 @@ impl ParseOptions {
     /// If this option is not enabled,
     /// the parser tries to use the plural formula specified in the metadata
     /// or `n != 1` if metadata is non-existent.
-    pub fn force_plural(mut self, plural: fn(u64) -> usize) -> Self {
+    pub fn force_plural(mut self, plural: fn(i64) -> usize) -> Self {
         self.force_plural = Some(plural);
         self
     }
@@ -174,7 +174,7 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
 ///
 /// It is valid for English and similar languages: plural will be used for any quantity
 /// different of 1.
-pub fn default_resolver(n: u64) -> usize {
+pub fn default_resolver(n: i64) -> usize {
     if n == 1 {
         0
     } else {

--- a/src/plurals.rs
+++ b/src/plurals.rs
@@ -8,7 +8,7 @@ pub enum Resolver {
     /// Use Ast::parse to get an Ast
     Expr(Ast),
     /// A function
-    Function(fn(u64) -> usize),
+    Function(fn(i64) -> usize),
 }
 
 /// Finds the index of a pattern, outside of parenthesis
@@ -74,7 +74,7 @@ pub enum Operator {
 }
 
 impl Ast {
-    fn resolve(&self, n: u64) -> usize {
+    fn resolve(&self, n: i64) -> usize {
         match *self {
             Ternary(ref cond, ref ok, ref nok) => {
                 if cond.resolve(n) == 0 {
@@ -280,7 +280,7 @@ impl Ast {
 impl Resolver {
     /// Returns the number of the correct plural form
     /// for `n` objects, as defined by the rule contained in this resolver.
-    pub fn resolve(&self, n: u64) -> usize {
+    pub fn resolve(&self, n: i64) -> usize {
         match *self {
             Expr(ref ast) => ast.resolve(n),
             Function(ref f) => f(n),


### PR DESCRIPTION
~Plural forms are allowed in gettext for negative numbers as well; the signature of `ngettext` et al is~

```
char * ngettext (const char * msgid, const char * msgid_plural, unsigned long int n);
```

*(See comment, I broke my brain.)*

This PR changes `Catalog::ngettext` and `Catalog::npgettext` to accept a `i64` instead of a `u64` to match ~this behaviour~ *observed real-world usage, at least in PHP*.