### PR TITLE
Add ability to merge catalogs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,11 @@ impl Catalog {
         }
     }
 
+    /// Merge another catalog.
+    pub fn merge(&mut self, catalog: &Catalog) {
+        self.strings.extend(catalog.strings.to_owned());
+    }
+
     /// Parses a gettext catalog from the given binary MO file.
     /// Returns the `Err` variant upon encountering an invalid file format
     /// or invalid byte sequence in strings.


### PR DESCRIPTION
I'm replacing an existing gettext implementation which supports splitting strings across multiple mo files, and merging multiple catalogs together.

To support this, I've added `Catalog::merge` which accepts another Catalog, and which extends the strings with those of the other catalog.