### PR TITLE
Store metadata in catalog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,11 @@ impl Catalog {
         }
     }
 
+    /// Merge another catalog.
+    pub fn merge(&mut self, catalog: &Catalog) {
+        self.strings.extend(catalog.strings.to_owned());
+    }
+
     /// Parses a gettext catalog from the given binary MO file.
     /// Returns the `Err` variant upon encountering an invalid file format
     /// or invalid byte sequence in strings.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@
 )]
 
 mod error;
-mod metadata;
+///
+pub mod metadata;
 mod parser;
 mod plurals;
 
@@ -54,10 +55,10 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::ops::Deref;
 
-use metadata::MetadataMap;
 use crate::parser::default_resolver;
 use crate::plurals::*;
 pub use crate::{error::Error, parser::ParseOptions};
+use metadata::MetadataMap;
 
 fn key_with_context(context: &str, key: &str) -> String {
     let mut result = context.to_owned();
@@ -70,7 +71,8 @@ fn key_with_context(context: &str, key: &str) -> String {
 /// parsed out of one MO file.
 #[derive(Clone, Debug)]
 pub struct Catalog {
-    strings: HashMap<String, Message>,
+    ///
+    pub strings: HashMap<String, Message>,
     resolver: Resolver,
     /// Creates a public optional property to store the metadata from MO files
     pub metadata: Option<MetadataMap>,
@@ -91,6 +93,11 @@ impl Catalog {
             resolver: Resolver::Function(default_resolver),
             metadata: None,
         }
+    }
+
+    /// Merge another catalog.
+    pub fn merge(&mut self, catalog: &Catalog) {
+        self.strings.extend(catalog.strings.to_owned());
     }
 
     /// Parses a gettext catalog from the given binary MO file.
@@ -183,7 +190,8 @@ impl Catalog {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct Message {
+///
+pub struct Message {
     id: String,
     context: Option<String>,
     translated: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ impl Message {
             id: id.into(),
             context: context.map(Into::into),
             translated: translated.into_iter().map(Into::into).collect(),
-			plural: None
+	    plural: None
         }
     }
 	/// Constructs a new `Message` instance with the given id, context, translated strings, 
@@ -233,7 +233,7 @@ impl Message {
             id: id.into(),
             context: context.map(Into::into),
             translated: translated.into_iter().map(Into::into).collect(),
-			plural: plural.map(Into::into),
+	    plural: plural.map(Into::into),
         }
     }
 
@@ -266,13 +266,13 @@ fn catalog_insert() {
         "anotherid",
         None,
         vec![],
-		Some("thisispluralid")
+	Some("thisispluralid")
     ));
     cat.insert(Message::with_plural(
         "anotherid",
         Some("context"),
         vec![],
-		Some("thisispluralid")
+	Some("thisispluralid")
     ));
     let mut keys = cat.strings.keys().collect::<Vec<_>>();
     keys.sort();
@@ -288,17 +288,17 @@ fn catalog_gettext() {
         "Image",
         None,
         vec!["Paveikslelis"],
-		Some("Images"),
+	Some("Images"),
     ));
     cat.insert(Message::with_plural(
         "Image",
         Some("context"),
         vec!["Paveikslelis"],
-		Some("Images"),
+	Some("Images"),
     ));
-	assert_eq!(cat.gettext("Text"), "Tekstas");
+    assert_eq!(cat.gettext("Text"), "Tekstas");
     assert_eq!(cat.gettext("context\x04Text"), "Tekstas");
-	assert_eq!(cat.gettext("Image"), "Paveikslelis");
+    assert_eq!(cat.gettext("Image"), "Paveikslelis");
     assert_eq!(cat.gettext("context\x04Image"), "Paveikslelis");
 }
 
@@ -352,7 +352,7 @@ fn catalog_npgettext_not_enough_forms_in_message() {
         "Text",
         Some("ctx"),
         vec!["Tekstas", "Tekstai"],
-		Some("Texts")
+	Some("Texts")
     ));
     cat.resolver = Resolver::Function(resolver);
     assert_eq!(cat.npgettext("ctx", "Text", "Texts", 0), "Tekstas");
@@ -367,7 +367,7 @@ fn catalog_pgettext() {
         "Text",
         Some("unit test"),
         vec!["Tekstas"],
-		Some("Texts")
+	Some("Texts")
     ));
     assert_eq!(cat.pgettext("unit test", "Text"), "Tekstas");
     assert_eq!(cat.pgettext("integration test", "Text"), "Text");
@@ -380,7 +380,7 @@ fn catalog_npgettext() {
         "Text",
         Some("unit test"),
         vec!["Tekstas", "Tekstai"],
-		Some("Texts"),
+	Some("Texts"),
     ));
 
     assert_eq!(cat.npgettext("unit test", "Text", "Texts", 1), "Tekstas");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub struct Message {
 
 impl Message {
     /// Constructs a new `Message` instance with the given id, context and translated strings.
-    fn new<T: Into<String>>( id: T, context: Option<T>, translated: Vec<T>) -> Self {
+    fn new<T: Into<String>>(id: T, context: Option<T>, translated: Vec<T>) -> Self {
         Message {
             id: id.into(),
             context: context.map(Into::into),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ pub struct Message {
     pub translated: Vec<String>,
 	/// An optional plural form of the original string, used for languages
     /// that have more than one form for plurals.
-    pub plural: Option<String>,
+    pub plural: Option<String>
 }
 
 impl Message {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,9 @@
 )]
 
 mod error;
-///
+/// Declare a public module named `metadata`.
+/// This module contains code related to handling metadata associated with translation entries.
+/// It provides functionality for managing key-value pairs of metadata.
 pub mod metadata;
 mod parser;
 mod plurals;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,8 +206,7 @@ pub struct Message {
     /// Translated strings for the message. Contains one string for each
     /// plural form in the target language.
     pub translated: Vec<String>,
-    /// An optional plural form of the original string, used for languages
-    /// that have more than one form for plurals.
+    /// An optional plural form of the original string, used with ngettext.
     pub plural: Option<String>
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,11 +213,7 @@ pub struct Message {
 
 impl Message {
 	/// Constructs a new `Message` instance with the given id, context and translated strings.
-    fn new<T: Into<String>>(
-        id: T,
-        context: Option<T>,
-        translated: Vec<T>,
-    ) -> Self {
+    fn new<T: Into<String>>( id: T, context: Option<T>, translated: Vec<T>) -> Self {
         Message {
             id: id.into(),
             context: context.map(Into::into),
@@ -261,6 +257,17 @@ fn catalog_insert() {
         None,
         vec![],
     ));
+	cat.insert(Message::new(
+        "thisisid",
+        Some("context"),
+        vec![],
+    ));
+    cat.insert(Message::with_plural(
+        "anotherid",
+        None,
+        vec![],
+		Some("thisispluralid")
+    ));
     cat.insert(Message::with_plural(
         "anotherid",
         Some("context"),
@@ -269,21 +276,30 @@ fn catalog_insert() {
     ));
     let mut keys = cat.strings.keys().collect::<Vec<_>>();
     keys.sort();
-    assert_eq!(keys, &["context\x04anotherid", "thisisid"])
+    assert_eq!(keys, &["anotherid", "context\x04anotherid", "context\x04thisisid", "thisisid"])
 }
 
 #[test]
 fn catalog_gettext() {
     let mut cat = Catalog::new();
     cat.insert(Message::new("Text", None, vec!["Tekstas"]));
+	cat.insert(Message::new("Text", Some("context"), vec!["Tekstas"]));
+	cat.insert(Message::with_plural(
+        "Image",
+        None,
+        vec!["Paveikslelis"],
+		Some("Images"),
+    ));
     cat.insert(Message::with_plural(
         "Image",
         Some("context"),
         vec!["Paveikslelis"],
 		Some("Images"),
     ));
-    assert_eq!(cat.gettext("Text"), "Tekstas");
-    assert_eq!(cat.gettext("Image"), "Image");
+	assert_eq!(cat.gettext("Text"), "Tekstas");
+    assert_eq!(cat.gettext("context\x04Text"), "Tekstas");
+	assert_eq!(cat.gettext("Image"), "Paveikslelis");
+    assert_eq!(cat.gettext("context\x04Image"), "Paveikslelis");
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub struct Message {
     pub id: String,
     /// An optional plural form of the original string, used for languages
     /// that have more than one form for plurals.
-    pub id_plural: Option<String>,
+    pub plural: Option<String>,
     /// An optional context for the translation, used for disambiguation
     /// when the same original string can have different translations
     /// depending on its usage.
@@ -214,13 +214,13 @@ pub struct Message {
 impl Message {
     fn new<T: Into<String>>(
         id: T,
-        id_plural: Option<T>,
+        plural: Option<T>,
         context: Option<T>,
         translated: Vec<T>,
     ) -> Self {
         Message {
             id: id.into(),
-            id_plural: id_plural.map(Into::into),
+            plural: plural.map(Into::into),
             context: context.map(Into::into),
             translated: translated.into_iter().map(Into::into).collect(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,13 +206,13 @@ pub struct Message {
     /// Translated strings for the message. Contains one string for each
     /// plural form in the target language.
     pub translated: Vec<String>,
-	/// An optional plural form of the original string, used for languages
+    /// An optional plural form of the original string, used for languages
     /// that have more than one form for plurals.
     pub plural: Option<String>
 }
 
 impl Message {
-	/// Constructs a new `Message` instance with the given id, context and translated strings.
+    /// Constructs a new `Message` instance with the given id, context and translated strings.
     fn new<T: Into<String>>( id: T, context: Option<T>, translated: Vec<T>) -> Self {
         Message {
             id: id.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ pub struct Message {
     /// plural form in the target language.
     pub translated: Vec<String>,
     /// An optional plural form of the original string, used with ngettext.
-    pub plural: Option<String>
+    pub plural: Option<String>,
 }
 
 impl Message {
@@ -217,25 +217,24 @@ impl Message {
             id: id.into(),
             context: context.map(Into::into),
             translated: translated.into_iter().map(Into::into).collect(),
-	    plural: None
+            plural: None,
         }
     }
-	/// Constructs a new `Message` instance with the given id, context, translated strings, 
-	/// and an optional plural form which will be used only when a plural form is available.
-	fn with_plural<T: Into<String>>(
+    /// Constructs a new `Message` instance with the given id, context, translated strings,
+    /// and an optional plural form which will be used only when a plural form is available.
+    fn with_plural<T: Into<String>>(
         id: T,
-		context: Option<T>,
+        context: Option<T>,
         translated: Vec<T>,
-		plural: Option<T>,
+        plural: Option<T>,
     ) -> Self {
         Message {
             id: id.into(),
             context: context.map(Into::into),
             translated: translated.into_iter().map(Into::into).collect(),
-	    plural: plural.map(Into::into),
+            plural: plural.map(Into::into),
         }
     }
-
 
     fn get_translated(&self, form_no: usize) -> Option<&str> {
         self.translated.get(form_no).map(|s| s.deref())
@@ -251,49 +250,49 @@ fn catalog_impls_send_sync() {
 #[test]
 fn catalog_insert() {
     let mut cat = Catalog::new();
-    cat.insert(Message::new(
-        "thisisid",
-        None,
-        vec![],
-    ));
-	cat.insert(Message::new(
-        "thisisid",
-        Some("context"),
-        vec![],
-    ));
+    cat.insert(Message::new("thisisid", None, vec![]));
+    cat.insert(Message::new("thisisid", Some("context"), vec![]));
     cat.insert(Message::with_plural(
         "anotherid",
         None,
         vec![],
-	Some("thisispluralid")
+        Some("thisispluralid"),
     ));
     cat.insert(Message::with_plural(
         "anotherid",
         Some("context"),
         vec![],
-	Some("thisispluralid")
+        Some("thisispluralid"),
     ));
     let mut keys = cat.strings.keys().collect::<Vec<_>>();
     keys.sort();
-    assert_eq!(keys, &["anotherid", "context\x04anotherid", "context\x04thisisid", "thisisid"])
+    assert_eq!(
+        keys,
+        &[
+            "anotherid",
+            "context\x04anotherid",
+            "context\x04thisisid",
+            "thisisid"
+        ]
+    )
 }
 
 #[test]
 fn catalog_gettext() {
     let mut cat = Catalog::new();
     cat.insert(Message::new("Text", None, vec!["Tekstas"]));
-	cat.insert(Message::new("Text", Some("context"), vec!["Tekstas"]));
-	cat.insert(Message::with_plural(
+    cat.insert(Message::new("Text", Some("context"), vec!["Tekstas"]));
+    cat.insert(Message::with_plural(
         "Image",
         None,
         vec!["Paveikslelis"],
-	Some("Images"),
+        Some("Images"),
     ));
     cat.insert(Message::with_plural(
         "Image",
         Some("context"),
         vec!["Paveikslelis"],
-	Some("Images"),
+        Some("Images"),
     ));
     assert_eq!(cat.gettext("Text"), "Tekstas");
     assert_eq!(cat.gettext("context\x04Text"), "Tekstas");
@@ -316,7 +315,7 @@ fn catalog_ngettext() {
             "Text",
             None,
             vec!["Tekstas", "Tekstai"],
-			Some("Texts"),
+            Some("Texts"),
         ));
         // n == 1, translation available
         assert_eq!(cat.ngettext("Text", "Texts", 1), "Tekstas");
@@ -351,7 +350,7 @@ fn catalog_npgettext_not_enough_forms_in_message() {
         "Text",
         Some("ctx"),
         vec!["Tekstas", "Tekstai"],
-	Some("Texts")
+        Some("Texts"),
     ));
     cat.resolver = Resolver::Function(resolver);
     assert_eq!(cat.npgettext("ctx", "Text", "Texts", 0), "Tekstas");
@@ -366,7 +365,7 @@ fn catalog_pgettext() {
         "Text",
         Some("unit test"),
         vec!["Tekstas"],
-	Some("Texts")
+        Some("Texts"),
     ));
     assert_eq!(cat.pgettext("unit test", "Text"), "Tekstas");
     assert_eq!(cat.pgettext("integration test", "Text"), "Text");
@@ -379,7 +378,7 @@ fn catalog_npgettext() {
         "Text",
         Some("unit test"),
         vec!["Tekstas", "Tekstai"],
-	Some("Texts"),
+        Some("Texts"),
     ));
 
     assert_eq!(cat.npgettext("unit test", "Text", "Texts", 1), "Tekstas");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::ops::Deref;
 
+use metadata::MetadataMap;
 use crate::parser::default_resolver;
 use crate::plurals::*;
 pub use crate::{error::Error, parser::ParseOptions};
@@ -71,6 +72,8 @@ fn key_with_context(context: &str, key: &str) -> String {
 pub struct Catalog {
     strings: HashMap<String, Message>,
     resolver: Resolver,
+    /// Creates a public optional property to store the metadata from MO files
+    pub metadata: Option<MetadataMap>,
 }
 
 impl Catalog {
@@ -86,6 +89,7 @@ impl Catalog {
         Catalog {
             strings: HashMap::new(),
             resolver: Resolver::Function(default_resolver),
+            metadata: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl Catalog {
     /// with the correct plural form for the number `n` of objects.
     /// Returns msg_id if a translation does not exist and `n == 1`,
     /// msg_id_plural otherwise.
-    pub fn ngettext<'a>(&'a self, msg_id: &'a str, msg_id_plural: &'a str, n: u64) -> &'a str {
+    pub fn ngettext<'a>(&'a self, msg_id: &'a str, msg_id_plural: &'a str, n: i64) -> &'a str {
         let form_no = self.resolver.resolve(n);
         let message = self.strings.get(msg_id);
         match message.and_then(|m| m.get_translated(form_no)) {
@@ -164,7 +164,7 @@ impl Catalog {
         msg_context: &str,
         msg_id: &'a str,
         msg_id_plural: &'a str,
-        n: u64,
+        n: i64,
     ) -> &'a str {
         let key = key_with_context(msg_context, &msg_id);
         let form_no = self.resolver.resolve(n);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -6,7 +6,9 @@ use crate::Error::MalformedMetadata;
 
 #[derive(Debug, Clone)]
 
-///
+/// Define a struct called `MetadataMap` that represents a map of metadata.
+/// It is a simple wrapper around a `HashMap` with `String` keys and `String` values.
+/// This struct is used to store key-value pairs of metadata associated with a translation entry or other data.
 pub struct MetadataMap(HashMap<String, String>);
 
 impl MetadataMap {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,11 +5,13 @@ use super::Error;
 use crate::Error::MalformedMetadata;
 
 #[derive(Debug, Clone)]
+
+///
 pub struct MetadataMap(HashMap<String, String>);
 
-impl MetadataMap {      
+impl MetadataMap {
     /// Returns a string that indicates the character set.
-    pub fn charset(&self) -> Option<&str> { 
+    pub fn charset(&self) -> Option<&str> {
         self.get("Content-Type")
             .and_then(|x| x.split("charset=").nth(1))
     }
@@ -19,7 +21,7 @@ impl MetadataMap {
     /// the number of elements.
     ///
     /// Defaults to `n_plurals = 2` and `plural = n!=1` (as in English).
-    pub fn plural_forms(&self) -> (Option<usize>, Option<& str>) {
+    pub fn plural_forms(&self) -> (Option<usize>, Option<&str>) {
         self.get("Plural-Forms")
             .map(|f| {
                 f.split(';').fold((None, None), |(n_pl, pl), prop| {
@@ -62,7 +64,10 @@ pub fn parse_metadata(blob: String) -> Result<MetadataMap, Error> {
             Some(p) => p,
             None => return Err(MalformedMetadata),
         };
-        map.insert(line[..pos].trim().to_string(), line[pos + 1..].trim().to_string());
+        map.insert(
+            line[..pos].trim().to_string(),
+            line[pos + 1..].trim().to_string(),
+        );
     }
     Ok(map)
 }
@@ -76,7 +81,10 @@ fn test_metadatamap_charset() {
         assert!(map.charset().is_none());
         map.insert("Content-Type".to_string(), "abc".to_string());
         assert!(map.charset().is_none());
-        map.insert("Content-Type".to_string(), "text/plain; charset=utf-42".to_string());
+        map.insert(
+            "Content-Type".to_string(),
+            "text/plain; charset=utf-42".to_string(),
+        );
         assert_eq!(map.charset().unwrap(), "utf-42");
     }
 }
@@ -93,13 +101,22 @@ fn test_metadatamap_plural() {
         map.insert("Plural-Forms".to_string(), "n_plurals=42".to_string());
         assert_eq!(map.plural_forms(), (Some(42), None));
         // plural is specified
-        map.insert("Plural-Forms".to_string(), "n_plurals=2; plural=n==12".to_string());
+        map.insert(
+            "Plural-Forms".to_string(),
+            "n_plurals=2; plural=n==12".to_string(),
+        );
         assert_eq!(map.plural_forms(), (Some(2), Some("n==12")));
         // plural before n_plurals
-        map.insert("Plural-Forms".to_string(), "plural=n==12; n_plurals=2".to_string());
+        map.insert(
+            "Plural-Forms".to_string(),
+            "plural=n==12; n_plurals=2".to_string(),
+        );
         assert_eq!(map.plural_forms(), (Some(2), Some("n==12")));
         // with spaces
-        map.insert("Plural-Forms".to_string(), " n_plurals = 42 ; plural = n >  10   ".to_string());
+        map.insert(
+            "Plural-Forms".to_string(),
+            " n_plurals = 42 ; plural = n >  10   ".to_string(),
+        );
         assert_eq!(map.plural_forms(), (Some(42), Some("n >  10")));
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -4,12 +4,12 @@ use std::ops::{Deref, DerefMut};
 use super::Error;
 use crate::Error::MalformedMetadata;
 
-#[derive(Debug)]
-pub struct MetadataMap<'a>(HashMap<&'a str, &'a str>);
+#[derive(Debug, Clone)]
+pub struct MetadataMap(HashMap<String, String>);
 
-impl<'a> MetadataMap<'a> {
+impl MetadataMap {      
     /// Returns a string that indicates the character set.
-    pub fn charset(&self) -> Option<&'a str> {
+    pub fn charset(&self) -> Option<&str> { 
         self.get("Content-Type")
             .and_then(|x| x.split("charset=").nth(1))
     }
@@ -19,7 +19,7 @@ impl<'a> MetadataMap<'a> {
     /// the number of elements.
     ///
     /// Defaults to `n_plurals = 2` and `plural = n!=1` (as in English).
-    pub fn plural_forms(&self) -> (Option<usize>, Option<&'a str>) {
+    pub fn plural_forms(&self) -> (Option<usize>, Option<& str>) {
         self.get("Plural-Forms")
             .map(|f| {
                 f.split(';').fold((None, None), |(n_pl, pl), prop| {
@@ -41,27 +41,28 @@ impl<'a> MetadataMap<'a> {
     }
 }
 
-impl<'a> Deref for MetadataMap<'a> {
-    type Target = HashMap<&'a str, &'a str>;
+impl Deref for MetadataMap {
+    type Target = HashMap<String, String>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> DerefMut for MetadataMap<'a> {
+impl DerefMut for MetadataMap {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-pub fn parse_metadata(blob: &str) -> Result<MetadataMap, Error> {
+/// Parses the given metadata blob into a `MetadataMap`.
+pub fn parse_metadata(blob: String) -> Result<MetadataMap, Error> {
     let mut map = MetadataMap(HashMap::new());
-    for line in blob.split('\n').filter(|s| s != &"") {
+    for line in blob.split('\n').filter(|s| !s.is_empty()) {
         let pos = match line.bytes().position(|b| b == b':') {
             Some(p) => p,
             None => return Err(MalformedMetadata),
         };
-        map.insert(line[..pos].trim(), line[pos + 1..].trim());
+        map.insert(line[..pos].trim().to_string(), line[pos + 1..].trim().to_string());
     }
     Ok(map)
 }
@@ -71,11 +72,11 @@ fn test_metadatamap_charset() {
     {
         let mut map = MetadataMap(HashMap::new());
         assert!(map.charset().is_none());
-        map.insert("Content-Type", "");
+        map.insert("Content-Type".to_string(), "".to_string());
         assert!(map.charset().is_none());
-        map.insert("Content-Type", "abc");
+        map.insert("Content-Type".to_string(), "abc".to_string());
         assert!(map.charset().is_none());
-        map.insert("Content-Type", "text/plain; charset=utf-42");
+        map.insert("Content-Type".to_string(), "text/plain; charset=utf-42".to_string());
         assert_eq!(map.charset().unwrap(), "utf-42");
     }
 }
@@ -86,19 +87,19 @@ fn test_metadatamap_plural() {
         let mut map = MetadataMap(HashMap::new());
         assert_eq!(map.plural_forms(), (None, None));
 
-        map.insert("Plural-Forms", "");
+        map.insert("Plural-Forms".to_string(), "".to_string());
         assert_eq!(map.plural_forms(), (None, None));
         // n_plural
-        map.insert("Plural-Forms", "n_plurals=42");
+        map.insert("Plural-Forms".to_string(), "n_plurals=42".to_string());
         assert_eq!(map.plural_forms(), (Some(42), None));
         // plural is specified
-        map.insert("Plural-Forms", "n_plurals=2; plural=n==12");
+        map.insert("Plural-Forms".to_string(), "n_plurals=2; plural=n==12".to_string());
         assert_eq!(map.plural_forms(), (Some(2), Some("n==12")));
         // plural before n_plurals
-        map.insert("Plural-Forms", "plural=n==12; n_plurals=2");
+        map.insert("Plural-Forms".to_string(), "plural=n==12; n_plurals=2".to_string());
         assert_eq!(map.plural_forms(), (Some(2), Some("n==12")));
         // with spaces
-        map.insert("Plural-Forms", " n_plurals = 42 ; plural = n >  10   ");
+        map.insert("Plural-Forms".to_string(), " n_plurals = 42 ; plural = n >  10   ".to_string());
         assert_eq!(map.plural_forms(), (Some(42), Some("n >  10")));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -120,7 +120,7 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
             None => None,
         };
         // extract msg_id singular and plural
-        let (id, id_plural) = match original
+        let (id, plural) = match original
             .iter()
             .position(|x| *x == 0)
             .map(|i| (&original[..i], &original[i + 1..]))
@@ -172,7 +172,7 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
             }
         }
 
-        catalog.insert(Message::new(id, id_plural, context, translated));
+        catalog.insert(Message::new(id, plural, context, translated));
 
         off_otable += 8;
         off_ttable += 8;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -147,7 +147,10 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
             .map(|b| encoding.decode(b, Strict))
             .collect::<Result<Vec<_>, _>>()?;
         if id == "" {
-            let map = parse_metadata(&*translated[0])?;
+            // Parse the metadata from the first translation string, returning early if there's an error.
+            let map = parse_metadata((*translated[0]).to_string())?;
+            // Set the metadata of the catalog with the parsed result.
+            catalog.metadata = Some(map.clone());           
             if let (Some(c), None) = (map.charset(), opts.force_encoding) {
                 encoding = encoding_from_whatwg_label(c).ok_or(UnknownEncoding)?;
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -172,7 +172,14 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
             }
         }
 
-        catalog.insert(Message::new(id, plural, context, translated));
+		// Checks the presence of a plural form for the message.
+		// If a plural form is provided, the message is inserted into the catalog using the `with_plural` method.
+		// Otherwise, the message is inserted using the default `new` method.
+		if plural.is_some() {
+			catalog.insert(Message::with_plural(id, context, translated, plural));
+		} else {
+			catalog.insert(Message::new(id, context, translated));
+		}
 
         off_otable += 8;
         off_ttable += 8;
@@ -261,7 +268,6 @@ fn test_parse_catalog() {
             catalog.strings["this is context\x04Text"],
             Message::new(
                 "Text",
-                None,
                 Some("this is context"),
                 vec!["Tekstas", "Tekstai"]
             )
@@ -274,7 +280,7 @@ fn test_parse_catalog() {
         assert_eq!(catalog.strings.len(), 2);
         assert_eq!(
             catalog.strings["Image"],
-            Message::new("Image", None, None, vec!["Nuotrauka", "Nuotraukos"])
+            Message::new("Image", None, vec!["Nuotrauka", "Nuotraukos"])
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,7 +28,7 @@ static utf8_encoding: EncodingRef = &encoding::codec::utf_8::UTF8Encoding;
 #[derive(Default)]
 pub struct ParseOptions {
     force_encoding: Option<EncodingRef>,
-    force_plural: Option<fn(u64) -> usize>,
+    force_plural: Option<fn(i64) -> usize>,
 }
 
 impl ParseOptions {
@@ -57,7 +57,7 @@ impl ParseOptions {
     /// If this option is not enabled,
     /// the parser tries to use the plural formula specified in the metadata
     /// or `n != 1` if metadata is non-existent.
-    pub fn force_plural(mut self, plural: fn(u64) -> usize) -> Self {
+    pub fn force_plural(mut self, plural: fn(i64) -> usize) -> Self {
         self.force_plural = Some(plural);
         self
     }
@@ -174,7 +174,7 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
 ///
 /// It is valid for English and similar languages: plural will be used for any quantity
 /// different of 1.
-pub fn default_resolver(n: u64) -> usize {
+pub fn default_resolver(n: i64) -> usize {
     if n == 1 {
         0
     } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -129,9 +129,11 @@ pub fn parse_catalog<R: io::Read>(mut file: R, opts: ParseOptions) -> Result<Cat
                 if b_plural.is_empty() {
                     (encoding.decode(b_singular, Strict)?, None)
                 } else {
+                    let plural_string = encoding.decode(b_plural, Strict)?;
+                    let trimmed_plural = plural_string.trim_end_matches('\0');
                     (
                         encoding.decode(b_singular, Strict)?,
-                        Some(encoding.decode(b_plural, Strict)?),
+                        Some(trimmed_plural.to_string()),
                     )
                 }
             }

--- a/src/plurals.rs
+++ b/src/plurals.rs
@@ -8,7 +8,7 @@ pub enum Resolver {
     /// Use Ast::parse to get an Ast
     Expr(Ast),
     /// A function
-    Function(fn(u64) -> usize),
+    Function(fn(i64) -> usize),
 }
 
 /// Finds the index of a pattern, outside of parenthesis
@@ -74,7 +74,7 @@ pub enum Operator {
 }
 
 impl Ast {
-    fn resolve(&self, n: u64) -> usize {
+    fn resolve(&self, n: i64) -> usize {
         match *self {
             Ternary(ref cond, ref ok, ref nok) => {
                 if cond.resolve(n) == 0 {
@@ -280,7 +280,7 @@ impl Ast {
 impl Resolver {
     /// Returns the number of the correct plural form
     /// for `n` objects, as defined by the rule contained in this resolver.
-    pub fn resolve(&self, n: u64) -> usize {
+    pub fn resolve(&self, n: i64) -> usize {
         match *self {
             Expr(ref ast) => ast.resolve(n),
             Function(ref f) => f(n),


### PR DESCRIPTION
Fixes #15. (Props @wisyhambolu.)

This allows us to pull the original plural form (in English), which is sometimes used as a lookup key in other software (i.e. in our case, to pass to a JS library that handles translations).

This incorporates my changes in #16 accidentally, can remove those if it's a 👍 on merging the key parts of it. See also prior review comments on https://github.com/rmccue/gettext-rs/pull/1